### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/test_multipage_navigation.html
+++ b/test_multipage_navigation.html
@@ -226,27 +226,21 @@
             const buttonText = button ? button.textContent : 'N/A';
             
             // Page info
-            document.getElementById('pageInfo').innerHTML = `
-                <div class="test-result success">URL: ${window.location.pathname}</div>
-                <div class="test-result success">Page loaded: ${new Date().toLocaleTimeString()}</div>
-            `;
+            document.getElementById('pageInfo').textContent = 
+                `URL: ${window.location.pathname}\n` +
+                `Page loaded: ${new Date().toLocaleTimeString()}`;
             
             // Theme info
-            document.getElementById('themeInfo').innerHTML = `
-                <div class="test-result success">Current theme: ${currentTheme}</div>
-                <div class="test-result success">Saved theme: ${savedTheme}</div>
-            `;
+            document.getElementById('themeInfo').textContent = 
+                `Current theme: ${currentTheme}\n` +
+                `Saved theme: ${savedTheme}`;
             
             // Event info
-            document.getElementById('eventInfo').innerHTML = `
-                <div class="test-result ${buttonExists ? 'success' : 'error'}">Button exists: ${buttonExists}</div>
-                <div class="test-result success">Button text: ${buttonText}</div>
-                <div class="test-result success">Debug entries: ${debugLog.length}</div>
-                <details style="margin-top: 10px;">
-                    <summary>Show debug log</summary>
-                    <pre style="background: #f0f0f0; padding: 10px; margin-top: 5px; max-height: 200px; overflow-y: auto;">${debugLog.slice(-10).join('\n')}</pre>
-                </details>
-            `;
+            document.getElementById('eventInfo').textContent = 
+                `Button exists: ${buttonExists}\n` +
+                `Button text: ${buttonText}\n` +
+                `Debug entries: ${debugLog.length}\n` +
+                `Debug log:\n${debugLog.slice(-10).join('\n')}`;
         }
 
         // Initialize immediately and on DOM ready


### PR DESCRIPTION
Potential fix for [https://github.com/StefanSpiess/stefanspiess_de/security/code-scanning/2](https://github.com/StefanSpiess/stefanspiess_de/security/code-scanning/2)

To fix the issue, the untrusted data (`button.textContent`) must be properly escaped or encoded before being inserted into the DOM using `innerHTML`. The best approach is to use `textContent` instead of `innerHTML` for inserting plain text into the DOM, as `textContent` does not interpret the input as HTML. This ensures that any special characters are treated as literal text rather than HTML.

#### Steps to fix:
1. Replace `innerHTML` with `textContent` for all instances where untrusted data is inserted into the DOM.
2. Ensure that the template literals used for constructing the debug information are modified to handle plain text safely.

#### Required changes:
- Modify lines 229–249 to use `textContent` instead of `innerHTML`.
- Adjust the code to construct the debug information as plain text rather than HTML.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
